### PR TITLE
add neighbors function

### DIFF
--- a/Geohash/__init__.py
+++ b/Geohash/__init__.py
@@ -18,4 +18,4 @@ You should have received a copy of the GNU Affero General Public
 License along with Geohash.  If not, see
 <http://www.gnu.org/licenses/>.
 """
-from geohash import decode_exactly, decode, encode
+from geohash import decode_exactly, decode, encode, neighbors, neighbor

--- a/Geohash/geohash.py
+++ b/Geohash/geohash.py
@@ -107,3 +107,31 @@ def encode(latitude, longitude, precision=12):
             bit = 0
             ch = 0
     return ''.join(geohash)
+
+def neighbor(geohash,direction):
+    (lat, lon, lat_err, lon_err)=decode_exactly(geohash)
+    neighborLat=lat+direction[0]*lat_err*2
+    neighborLon=lon+direction[1]*lon_err*2
+    return encode(neighborLat, neighborLon, len(geohash))
+
+def __encodeNeighbor(lat,lon,lat_err, lon_err,direction,length):
+        neighbor_lat = lat + direction[0] * lat_err;
+        neighbor_lon = lon + direction[1] * lon_err;
+        return encode(neighbor_lat, neighbor_lon,length )
+
+def neighbors(geohash):
+    hashstringLength=len(geohash)
+    (lat, lon, lat_err, lon_err)=decode_exactly(geohash)
+
+    neighborHashList=[
+                    __encodeNeighbor(lat, lon, lat_err*2, lon_err*2,[-1,1],hashstringLength),
+                    __encodeNeighbor(lat, lon, lat_err*2, lon_err*2,[0,1],hashstringLength),
+                    __encodeNeighbor(lat, lon, lat_err*2, lon_err*2,[1,1],hashstringLength),
+                    __encodeNeighbor(lat, lon, lat_err*2, lon_err*2,[-1,0],hashstringLength),
+                    __encodeNeighbor(lat, lon, lat_err*2, lon_err*2,[0,0],hashstringLength),
+                    __encodeNeighbor(lat, lon, lat_err*2, lon_err*2,[1,0],hashstringLength),
+                    __encodeNeighbor(lat, lon, lat_err*2, lon_err*2,[-1,-1],hashstringLength),
+                    __encodeNeighbor(lat, lon, lat_err*2, lon_err*2,[0,-1],hashstringLength),
+                    __encodeNeighbor(lat, lon, lat_err*2, lon_err*2,[1,-1],hashstringLength)
+    ]
+    return neighborHashList


### PR DESCRIPTION
use `Geohash.neighbors('ezs42e44yx96')` to find the 8 blocks around the 'ezs42e44yx96'
like this:

```
>>> import Geohash
>>> Geohash.neighbors('ezs42e44yx96')
['ezs42e44yx99', 'ezs42e44yx9d', 'ezs42e44yx9e', 'ezs42e44yx93', 'ezs42e44yx96', 'ezs42e44yx97', 'ezs42e44yx91', 'ezs42e44yx94', 'ezs42e44yx95']
```
