### PR TITLE
Added '.' to specify location

### DIFF
--- a/Geohash/__init__.py
+++ b/Geohash/__init__.py
@@ -18,4 +18,4 @@ You should have received a copy of the GNU Affero General Public
 License along with Geohash.  If not, see
 <http://www.gnu.org/licenses/>.
 """
-from geohash import decode_exactly, decode, encode
+from .geohash import decode_exactly, decode, encode


### PR DESCRIPTION
Added a period ('.') to specify that the geohash module is co-located to the **init** module. There issues in some platforms where there will be a "can't find module" error.
