### PR TITLE
Added . for correction

### DIFF
--- a/Geohash/__init__.py
+++ b/Geohash/__init__.py
@@ -18,4 +18,4 @@ You should have received a copy of the GNU Affero General Public
 License along with Geohash.  If not, see
 <http://www.gnu.org/licenses/>.
 """
-from geohash import decode_exactly, decode, encode
+from .geohash import decode_exactly, decode, encode


### PR DESCRIPTION
Without "." in front of geohash, the geohash.py script is not being recognized  by the init file.